### PR TITLE
Add mustache template for BrAPP links in navbar menu.

### DIFF
--- a/brapps.php
+++ b/brapps.php
@@ -30,7 +30,9 @@
             include("html/scripts.html");
         ?>
         <script>
-            $.getJSON("json/app-links.json", function(links){
+            // Load BrAPPs section template
+            // 'brappLinks' is defined in 'html/scripts.html'
+            brappLinks.done(function(links){
               $(links).each(function(i, e) {
                 var template = $('#brapp-template').html();
                 Mustache.parse(template); // optional, speeds up future uses
@@ -39,6 +41,6 @@
               });
             });
         </script>
-        
+
     </body>
 </html>

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,9 @@
 # Build with : docker build -t brapi.org -f dev.Dockerfile ./
 # run with : docker run --name="brapi.org" -p 8080:80 -d brapi.org
 
+# All in one (build, run, delete container, delete image) :
+# docker build -t brapi.org -f dev.Dockerfile ./ && docker run --name="brapi.org" -p 80:80 brapi.org && docker rm -f brapi.org && docker rmi brapi.org
+ 
 FROM richarvey/nginx-php-fpm
 
 COPY ./ /var/www/html/

--- a/html/menu.html
+++ b/html/menu.html
@@ -55,12 +55,14 @@
             </li>
             <li class="dropdown">
                 <a class="dropdown-toggle" href="brapps.php" data-toggle="dropdown">Applications</a>
-                <ul class="dropdown-menu">
-                    <li>
-                        <a href="https://solgenomics.github.io/BrAPI-Graphical-Filtering/">Graphical Filtering</a>
-                    </li>
-                </ul>
+                <ul class="dropdown-menu" id="brapp-links"></ul>
             </li>
         </ul>
     </div>
 </div>
+
+<script id="brapp-links-template" type="x-tmpl-mustache">
+    <li>
+        <a href="{{ url }}">{{ title }}</a>
+    </li>
+</script>

--- a/html/scripts.html
+++ b/html/scripts.html
@@ -30,4 +30,17 @@
         addEventTag($(events)['0']);
         addEventTag($(events)['1']);
     });
+
+    // Load JSON once, use twice (here and in 'brapps.php')
+    var brappLinks = $.getJSON("json/app-links.json");
+
+    // Load BrAPP links template in menu
+    brappLinks.done(function(links){
+      $(links).each(function(i, e) {
+        var template = $('#brapp-links-template').html();
+        Mustache.parse(template); // optional, speeds up future uses
+        var rendered = Mustache.render(template, e);
+        $('#brapp-links').append(rendered);
+      });
+    });
 </script>


### PR DESCRIPTION
This pull request adds mustache templating in the navbar menu so that the BrAPP links can be dynamically loaded from [json/app-links.json](https://github.com/plantbreeding/brapi-website/blob/master/json/app-links.json)